### PR TITLE
Fixed ghost(?) logs

### DIFF
--- a/create_client.sh
+++ b/create_client.sh
@@ -68,3 +68,4 @@ echo "######################################################"
 cat ${destination_file}.conf
 
 systemctl restart wg-quick@wg0
+systemctl restart wireguard-logging

--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -59,26 +59,31 @@ do
                 seconds=`echo $word | grep -oE "[0-9]{1,2} second" | awk {'print $1'}`
                 #endpoint=`echo $word  | awk -F' |:' {'print $6'}`
                 durationMessage=''
+                continue=true
                 if [ ! -z $days ];then
                         day_seconds=$(($days*24*60*60*60))
                         durationMessage+="$days Day(s),"
+                        continue=false
                 fi
                 if [ ! -z $hours ];then
                         hour_seconds=$((hours*60*60))
                         durationMessage+="$hours Hour(s), "
+                        continue=false
                 fi
 
                 if [ ! -z $minutes ];then
                         minute_seconds=$((minutes*60))
                         durationMessage+="$minutes minute(s), "
+                        continue=false
                 fi
 
                 if [ ! -z $seconds ];then
                         second_seconds=$((seconds))
                         durationMessage+="$seconds second(s) ago"
+                        continue=false
                 fi
 
-                if [ -z $seconds ];then
+                if [ $continue ];then
                     continue
                 fi
 

--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -83,7 +83,7 @@ do
                         continue=false
                 fi
 
-                if [ $continue ];then
+                if [ $continue == "true" ];then
                     continue
                 fi
 

--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -78,6 +78,10 @@ do
                         durationMessage+="$seconds second(s) ago"
                 fi
 
+                if [ -z $seconds ];then
+                    continue
+                fi
+
                 duration=$((hour_seconds + minute_seconds + second_seconds))
                 user=`grep -irl ${peer} /etc/wireguard/clients/ | awk -F'/' {'print $5'}`
                 #echo "User: $user , Duration: $duration, Peer: $peer, IP: $endpoint, Threshold: $threshold"


### PR DESCRIPTION
Fixed the issue of ghost logs, by skipping logs where the seconds value is null. And the `create_client.sh` script now restarts wireguard-logging after a new user has been created. Without restart, we were missing out on some logs. 