### PR TITLE
Added: Check for root user. Fixed: Script output was generating invalid client configs and QR codes.

### DIFF
--- a/create_client.sh
+++ b/create_client.sh
@@ -3,7 +3,7 @@
 # personal configuration
 SERVER_IP=YOUR_SERVER_IP
 LISTEN_PORT=YOUR_WIREGUARD_LISTEN_PORT
-DNS_SERVERS="DNS_IP_1 , DNS_IP_2"
+DNS_SERVERS="DNS_IP_1, DNS_IP_2"
 SERVER_PUBLIC_KEY="SERVER_PUBLIC_KEY"
 PUSH_ROUTE_ALL="0.0.0.0/0, ::/0"
 PUSH_ROUTE_INTRANET="192.168.x.0/24, 192.168.x.0/24"
@@ -50,13 +50,14 @@ echo "Creating Client Config"
 
 cat <<EOF > ${destination_file}.conf
 [Interface]
-Address = ${clientIP}/24
 PrivateKey = ${private_key}
-PresharedKey = ${preshared_key}
+Address = ${clientIP}/24
+ListenPort = ${LISTEN_PORT}
 DNS = ${DNS_SERVERS}
 
 [Peer]
 PublicKey = ${SERVER_PUBLIC_KEY}
+PresharedKey = ${preshared_key}
 AllowedIPs = ${PUSH_ROUTE}
 Endpoint = ${SERVER_IP}:${LISTEN_PORT}
 EOF
@@ -70,6 +71,7 @@ cat << EOF >> ${SERVER_CONFIG}
 #${client_name}
 [Peer]
 PublicKey = ${public_key}
+PresharedKey = ${preshared_key}
 AllowedIPs = ${clientIP}/32
 EOF
 

--- a/create_client.sh
+++ b/create_client.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# personal configuration
 SERVER_IP=YOUR_SERVER_IP
 LISTEN_PORT=YOUR_WIREGUARD_LISTEN_PORT
 DNS_SERVERS="DNS_IP_1 , DNS_IP_2"
@@ -7,6 +9,14 @@ PUSH_ROUTE_ALL="0.0.0.0/0, ::/0"
 PUSH_ROUTE_INTRANET="192.168.x.0/24, 192.168.x.0/24"
 SERVER_CONFIG='wg0.conf'
 IP_RANGE='192.168.x.1 and 192.168.x.253'
+
+# modifying network interfaces and taking them up and down requires super user privlages, are we running as root?
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root"
+   exit 1
+fi
+
+# prompt for client config params
 read -p "Enter Client Name:" client_name_temp
 read -p "Push All Routes ? If not only Intranet will be routed (y/n):" confirmRoutes
 echo "What do you want the client IP to be,must be between ${IP_RANGE} ?:"


### PR DESCRIPTION
**Added:**
Check for root user on script launch.

**Fixed:**
Incorrectly placed the `PresharedKey` in the `[Interface]` block of config, which generated invalid client `.conf` files and QR codes. Moved `PresharedKey` to the respective `[Peer]` blocks. Script again generates valid Wireguard client configs and QR codes.