### PR TITLE
Fix issue with service file, add feature to configure PersistentKeepalive for client

### DIFF
--- a/create_client.sh
+++ b/create_client.sh
@@ -23,6 +23,11 @@ echo "What do you want the client IP to be,must be between ${IP_RANGE} ?:"
 echo "These Ips are already used:"
 grep AllowedIPs ${SERVER_CONFIG}
 read -p "Enter client IP you want to assign:" clientIP
+read -p "Use PersistentKeepalive in client config? (y/n):" useKeepalive
+if [ "${useKeepalive}" == 'y' ]; then
+        read -p "Keepalive interval in seconds (blank for default of 25):" keepaliveSecs
+        keepaliveSecs="${keepaliveSecs:=25}"
+fi
 
 if [ "${confirmRoutes}" == 'y' ];then
         PUSH_ROUTE=${PUSH_ROUTE_ALL}
@@ -61,6 +66,11 @@ PresharedKey = ${preshared_key}
 AllowedIPs = ${PUSH_ROUTE}
 Endpoint = ${SERVER_IP}:${LISTEN_PORT}
 EOF
+
+# Append PersistentKeepalive to client config if enabled
+if [ "${useKeepalive}" == 'y' ]; then
+        echo "PersistentKeepalive = ${keepaliveSecs}" >> ${destination_file}.conf
+fi
 
 # append config to server
 systemctl stop wg-quick@wg0

--- a/wireguard-logging.service
+++ b/wireguard-logging.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/bin/sh /etc/wireguard/wireguard-logging.sh
+ExecStart=/bin/bash /etc/wireguard/wireguard-logging.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixed an issue with the systemd service file that would cause the logging service to fail to start on Debian Linux. Added a feature to create_client.sh that gives the user the option to easily configure PersistentKeepalive for the client.