### PR TITLE
Remove spaces from peer and endpoint

### DIFF
--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -106,7 +106,7 @@ do
                         grep -i $user[[:space:]] ${connection_info_file} >> /dev/null
                         if [ $? -eq 0 ];then
                                 sed -i "/$user/d" ${connection_info_file}
-                                echo "`date` - User $user $endpoint  disconnected $durationMessage" >> ${log_file}
+                                echo "`date` - User $user $endpoint disconnected $durationMessage" >> ${log_file}
                                 if [ "$notify_by_email" == "yes" ];then
                                 	notify "$user" "$endpoint" "$durationMessage" "Disconnected"
                                 fi

--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -51,8 +51,8 @@ do
                 #echo "-------------------------------------------"
                 #echo "word: $word"
                 #echo "-------------------------------------------"
-                endpoint=`echo $word | grep -o 'endpoint:\s\+\S*\W' | awk -F':' {'print $2'}`
-                peer=`echo $word | grep -o 'peer:\s\+\S*\W' | awk -F':' {'print $2'}`
+                endpoint=`echo $word | grep -o 'endpoint:\s\+\S*\W' | awk -F':' {'print $2'} | tr -d ' '`
+                peer=`echo $word | grep -o 'peer:\s\+\S*\W' | awk -F':' {'print $2'} | tr -d ' '`
                 days=`echo $word | grep -oE "[0-9]{1,3} day" | awk {'print $1'}`
                 hours=`echo $word | grep -oE "[0-9]{1,2} hour" | awk {'print $1'}`
                 minutes=`echo $word | grep -oE "[0-9]{1,2} minute" | awk {'print $1'}`


### PR DESCRIPTION
Both the peer and endpoint variables have spaces in them. This is visible for endpoint during the notifications.