### PR TITLE
Actually use day_seconds

### DIFF
--- a/wireguard-logging.sh
+++ b/wireguard-logging.sh
@@ -87,7 +87,7 @@ do
                     continue
                 fi
 
-                duration=$((hour_seconds + minute_seconds + second_seconds))
+                duration=$((day_seconds + hour_seconds + minute_seconds + second_seconds))
                 user=`grep -rl ${peer} /etc/wireguard/clients/ | awk -F'/' {'print $5'}`
                 #echo "User: $user , Duration: $duration, Peer: $peer, IP: $endpoint, Threshold: $threshold"
                 if [ $duration -le $threshold ];then


### PR DESCRIPTION
The variable day_seconds was not being used, causing extra notifications for clients that are disconnected for multiple days.